### PR TITLE
Add PlatformIO setup with HeatPump demo sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # esp32-matter-mitsubishi-ac
-Control a Mitsubishi AC unit using an ESP32 module
+
+Control a Mitsubishi AC unit using an ESP32 module.
+
+## PlatformIO project
+
+This repository contains a ready-to-build [PlatformIO](https://platformio.org/) project configured for the `esp32-c3-devkitc-02` board, the Arduino framework, and the [SwiCago/HeatPump](https://github.com/SwiCago/HeatPump) library. The configuration automatically pulls the HeatPump driver as a dependency and sets up the serial monitor at 115200 baud.
+
+### Building and uploading
+
+```bash
+pio run              # build the firmware
+pio run -t upload    # flash over USB
+pio device monitor   # open the serial console
+```
+
+### Hardware configuration
+
+The demo sketch in `src/main.cpp` uses `Serial1` to communicate with the heat pump over the CN105 connector. By default the firmware expects:
+
+- RX on GPIO 4 (`HEATPUMP_SERIAL_RX_PIN`)
+- TX on GPIO 5 (`HEATPUMP_SERIAL_TX_PIN`)
+- Serial speed of 2400 baud with even parity (`HEATPUMP_SERIAL_BAUD_RATE`)
+
+You can adjust these defaults by defining the macros above in `platformio.ini` (using `build_flags = -DHEATPUMP_SERIAL_RX_PIN=<pin> ...`) or by editing `src/main.cpp` directly.
+
+On boot the firmware connects to the heat pump, applies a set of initial settings (power on, HEAT mode, 22 °C, AUTO fan), and then periodically synchronises with the unit. Status, settings changes, and room temperature updates are logged to the USB serial console to provide visibility into the connection.

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,6 @@
 platform = espressif32
 board = esp32-c3-devkitc-02
 framework = arduino
+monitor_speed = 115200
+lib_deps =
+  https://github.com/SwiCago/HeatPump

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,118 @@
 #include <Arduino.h>
+#include <HeatPump.h>
 
-// put function declarations here:
-int myFunction(int, int);
+#ifndef HEATPUMP_SERIAL_RX_PIN
+#define HEATPUMP_SERIAL_RX_PIN 4
+#endif
+
+#ifndef HEATPUMP_SERIAL_TX_PIN
+#define HEATPUMP_SERIAL_TX_PIN 5
+#endif
+
+#ifndef HEATPUMP_SERIAL_BAUD_RATE
+#define HEATPUMP_SERIAL_BAUD_RATE 2400
+#endif
+
+namespace {
+
+constexpr uint32_t kLogBaudRate = 115200;
+
+HeatPump heatPump;
+HardwareSerial &heatPumpSerial = Serial1;
+bool heatPumpConnected = false;
+
+void printHeatPumpTimers(const heatpumpTimers &timers) {
+  Serial.printf("  Timer mode: %s\n", timers.mode ? timers.mode : "UNKNOWN");
+  Serial.printf("  On timer set/remain: %d/%d minutes\n", timers.onMinutesSet, timers.onMinutesRemaining);
+  Serial.printf("  Off timer set/remain: %d/%d minutes\n", timers.offMinutesSet, timers.offMinutesRemaining);
+}
+
+void printHeatPumpSettings(const heatpumpSettings &settings) {
+  Serial.println("Current heat pump settings:");
+  Serial.printf("  Power: %s\n", settings.power ? settings.power : "UNKNOWN");
+  Serial.printf("  Mode: %s\n", settings.mode ? settings.mode : "UNKNOWN");
+  Serial.printf("  Set temperature: %.1f °C\n", settings.temperature);
+  Serial.printf("  Fan speed: %s\n", settings.fan ? settings.fan : "UNKNOWN");
+  Serial.printf("  Vane (vertical): %s\n", settings.vane ? settings.vane : "UNKNOWN");
+  Serial.printf("  Wide vane (horizontal): %s\n", settings.wideVane ? settings.wideVane : "UNKNOWN");
+  Serial.printf("  iSee sensor detected: %s\n", settings.iSee ? "yes" : "no");
+}
+
+void printHeatPumpStatus(const heatpumpStatus &status) {
+  Serial.println("Heat pump status:");
+  Serial.printf("  Room temperature: %.1f °C\n", status.roomTemperature);
+  Serial.printf("  Operating: %s\n", status.operating ? "yes" : "no");
+  Serial.printf("  Compressor frequency: %d\n", status.compressorFrequency);
+  printHeatPumpTimers(status.timers);
+}
+
+void onHeatPumpSettingsChanged() {
+  printHeatPumpSettings(heatPump.getSettings());
+}
+
+void onHeatPumpStatusChanged(heatpumpStatus status) {
+  printHeatPumpStatus(status);
+}
+
+void onHeatPumpRoomTempChanged(float roomTemperature) {
+  Serial.printf("Room temperature changed: %.1f °C\n", roomTemperature);
+}
+
+void configureInitialSettings() {
+  heatPump.setPowerSetting(true);
+  heatPump.setModeSetting("HEAT");
+  heatPump.setTemperature(22.0f);
+  heatPump.setFanSpeed("AUTO");
+  heatPump.setVaneSetting("AUTO");
+  heatPump.setWideVaneSetting("|");
+  heatPump.enableAutoUpdate();
+  heatPump.enableExternalUpdate();
+
+  if (heatPump.update()) {
+    Serial.println("Initial settings sent to the heat pump interface.");
+  } else {
+    Serial.println("Failed to send initial settings to the heat pump interface.");
+  }
+}
+
+void connectHeatPump() {
+  Serial.printf("Connecting to heat pump (RX pin %d, TX pin %d) ...\n", HEATPUMP_SERIAL_RX_PIN, HEATPUMP_SERIAL_TX_PIN);
+  heatPumpConnected = heatPump.connect(&heatPumpSerial,
+                                       HEATPUMP_SERIAL_BAUD_RATE,
+                                       HEATPUMP_SERIAL_RX_PIN,
+                                       HEATPUMP_SERIAL_TX_PIN);
+
+  if (!heatPumpConnected) {
+    Serial.println("Failed to connect to the heat pump interface. Check wiring and serial configuration.");
+    return;
+  }
+
+  Serial.println("Successfully connected to the heat pump interface.");
+  configureInitialSettings();
+}
+
+}  // namespace
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Serial.begin(kLogBaudRate);
+  while (!Serial && millis() < 2000) {
+    delay(10);
+  }
+
+  Serial.println();
+  Serial.println("ESP32 Mitsubishi Heat Pump controller demo");
+
+  heatPump.setSettingsChangedCallback(onHeatPumpSettingsChanged);
+  heatPump.setStatusChangedCallback(onHeatPumpStatusChanged);
+  heatPump.setRoomTempChangedCallback(onHeatPumpRoomTempChanged);
+
+  connectHeatPump();
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-}
+  if (heatPumpConnected) {
+    heatPump.sync();
+  }
 
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
+  delay(1000);
 }


### PR DESCRIPTION
## Summary
- configure the PlatformIO project for the ESP32-C3 Arduino framework and pull in the SwiCago HeatPump library
- replace the placeholder sketch with a Serial1-based demo that connects to the heat pump and logs state changes
- document build steps and hardware configuration details in the README

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e514860a64832493008c9d7b259749