### PR TITLE
Add PlatformIO environment for Seeed XIAO ESP32C6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,39 @@ Control a Mitsubishi AC unit using an ESP32 module.
 
 ## PlatformIO project
 
-This repository contains a ready-to-build [PlatformIO](https://platformio.org/) project configured for the `esp32-c3-devkitc-02` board, the Arduino framework, and the [SwiCago/HeatPump](https://github.com/SwiCago/HeatPump) library. The configuration automatically pulls the HeatPump driver as a dependency and sets up the serial monitor at 115200 baud.
+This repository contains a ready-to-build [PlatformIO](https://platformio.org/) project configured for the Arduino framework and the [SwiCago/HeatPump](https://github.com/SwiCago/HeatPump) library. Two example environments are included out of the box:
+
+- `esp32-c3-devkitc-02` – the original reference target.
+- `seeed_xiao_esp32c6` – suitable for the [Seeed Studio XIAO ESP32C6](https://wiki.seeedstudio.com/XIAO_ESP32C6_Getting_Started/) board.
+
+Both environments share the same source code and automatically pull the HeatPump driver dependency while configuring the serial monitor at 115200 baud.
 
 ### Building and uploading
 
 ```bash
-pio run              # build the firmware
-pio run -t upload    # flash over USB
-pio device monitor   # open the serial console
+# Build for the default ESP32-C3 DevKitC-02 target
+pio run
+
+# Build & upload for the default target
+pio run -t upload
+
+# Build & upload for the Seeed Studio XIAO ESP32C6
+pio run -e seeed_xiao_esp32c6 -t upload
+
+# Open the serial console (works for either environment)
+pio device monitor
 ```
 
 ### Hardware configuration
 
-The demo sketch in `src/main.cpp` uses `Serial1` to communicate with the heat pump over the CN105 connector. By default the firmware expects:
+The demo sketch in `src/main.cpp` uses `Serial1` to communicate with the heat pump over the CN105 connector. The default pin mappings differ slightly per environment:
 
-- RX on GPIO 4 (`HEATPUMP_SERIAL_RX_PIN`)
-- TX on GPIO 5 (`HEATPUMP_SERIAL_TX_PIN`)
-- Serial speed of 2400 baud with even parity (`HEATPUMP_SERIAL_BAUD_RATE`)
+| Environment | RX pin (`HEATPUMP_SERIAL_RX_PIN`) | TX pin (`HEATPUMP_SERIAL_TX_PIN`) |
+|-------------|-----------------------------------|-----------------------------------|
+| `esp32-c3-devkitc-02` | GPIO 4 | GPIO 5 |
+| `seeed_xiao_esp32c6`  | GPIO 17 (D7) | GPIO 16 (D6) |
+
+Both configurations use a serial speed of 2400 baud with even parity (`HEATPUMP_SERIAL_BAUD_RATE`).
 
 You can adjust these defaults by defining the macros above in `platformio.ini` (using `build_flags = -DHEATPUMP_SERIAL_RX_PIN=<pin> ...`) or by editing `src/main.cpp` directly.
 

--- a/boards/seeed_xiao_esp32c6.json
+++ b/boards/seeed_xiao_esp32c6.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_XIAO_ESP32C6",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x2886",
+        "0x0048"
+      ],
+      [
+        "0x2886",
+        "0x8048"
+      ]
+    ],
+    "mcu": "esp32c6",
+    "variant": "XIAO_ESP32C6"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "zigbee",
+    "thread"
+  ],
+  "debug": {
+    "openocd_target": "esp32c6.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Seeed Studio XIAO ESP32C6",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://wiki.seeedstudio.com/XIAO_ESP32C6_Getting_Started/",
+  "vendor": "Seeed Studio"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,17 +1,20 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
+[platformio]
+default_envs = esp32-c3-devkitc-02
 
-[env:esp32-c3-devkitc-02]
-platform = espressif32
-board = esp32-c3-devkitc-02
+[env]
+platform = espressif32@^6.5.0
 framework = arduino
 monitor_speed = 115200
 lib_deps =
   https://github.com/SwiCago/HeatPump
+
+[env:esp32-c3-devkitc-02]
+board = esp32-c3-devkitc-02
+
+[env:seeed_xiao_esp32c6]
+board = seeed_xiao_esp32c6
+platform_packages =
+  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
+build_flags =
+  -DHEATPUMP_SERIAL_RX_PIN=17
+  -DHEATPUMP_SERIAL_TX_PIN=16


### PR DESCRIPTION
## Summary
- add a custom PlatformIO board definition that enables Arduino builds for the Seeed Studio XIAO ESP32C6
- provide a dedicated PlatformIO environment with appropriate serial pin defaults and shared configuration
- update the documentation with build instructions and hardware pin mapping for the new board

## Testing
- not run (PlatformIO CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e51c1b2744832496d0753b5d9e4b2a