### PR TITLE
Add Wi-Fi and Matter stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,22 @@ Both configurations use a serial speed of 2400 baud with even parity (`HEATPUMP_
 You can adjust these defaults by defining the macros above in `platformio.ini` (using `build_flags = -DHEATPUMP_SERIAL_RX_PIN=<pin> ...`) or by editing `src/main.cpp` directly.
 
 On boot the firmware connects to the heat pump, applies a set of initial settings (power on, HEAT mode, 22 °C, AUTO fan), and then periodically synchronises with the unit. Status, settings changes, and room temperature updates are logged to the USB serial console to provide visibility into the connection.
+
+### Wi-Fi and Matter support
+
+The sketch now connects to your Wi-Fi network to expose a stubbed Matter bridge that periodically reports its health over the serial console. Configure the Wi-Fi credentials at build time via the following macros (for example inside `platformio.ini`):
+
+```ini
+build_flags =
+  -DWIFI_SSID=\"your-ssid\"
+  -DWIFI_PASSWORD=\"super_secret\"
+```
+
+Additional tuning knobs are available:
+
+| Macro | Purpose | Default |
+|-------|---------|---------|
+| `WIFI_CONNECT_TIMEOUT_MS` | Time (in milliseconds) to wait for the initial Wi-Fi connection attempt. | `15000` |
+| `WIFI_RECONNECT_INTERVAL_MS` | Minimum delay between automatic reconnect attempts once disconnected. | `10000` |
+
+Once Wi-Fi is connected the Matter bridge simulator logs a heartbeat every five seconds to confirm that the ESP32 is ready for commissioning commands. The heartbeat currently serves as a placeholder for future integration with the official ESP Matter SDK while still providing a visible indicator that wireless connectivity is active.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <HeatPump.h>
+#include <WiFi.h>
 
 #ifndef HEATPUMP_SERIAL_RX_PIN
 #define HEATPUMP_SERIAL_RX_PIN 4
@@ -13,13 +14,100 @@
 #define HEATPUMP_SERIAL_BAUD_RATE 2400
 #endif
 
+#ifndef WIFI_SSID
+#define WIFI_SSID "YOUR_WIFI_SSID"
+#endif
+
+#ifndef WIFI_PASSWORD
+#define WIFI_PASSWORD "YOUR_WIFI_PASSWORD"
+#endif
+
+#ifndef WIFI_CONNECT_TIMEOUT_MS
+#define WIFI_CONNECT_TIMEOUT_MS 15000
+#endif
+
+#ifndef WIFI_RECONNECT_INTERVAL_MS
+#define WIFI_RECONNECT_INTERVAL_MS 10000
+#endif
+
 namespace {
 
 constexpr uint32_t kLogBaudRate = 115200;
+constexpr uint32_t kMatterHeartbeatMs = 5000;
 
 HeatPump heatPump;
 HardwareSerial &heatPumpSerial = Serial1;
 bool heatPumpConnected = false;
+unsigned long lastWifiAttempt = 0;
+
+class MatterBridge {
+ public:
+  void begin() {
+    if (initialized_) {
+      return;
+    }
+
+    Serial.println("Initializing Matter bridge (stub)");
+    Serial.println("Registering Mitsubishi heat pump endpoints for power, mode, and temperature.");
+    initialized_ = true;
+    lastHeartbeat_ = millis();
+  }
+
+  void loop() {
+    if (!initialized_ || WiFi.status() != WL_CONNECTED) {
+      return;
+    }
+
+    const unsigned long now = millis();
+    if (now - lastHeartbeat_ >= kMatterHeartbeatMs) {
+      Serial.println("Matter bridge heartbeat: ready for commissioning commands over Wi-Fi.");
+      lastHeartbeat_ = now;
+    }
+  }
+
+ private:
+  bool initialized_ = false;
+  unsigned long lastHeartbeat_ = 0;
+};
+
+MatterBridge matterBridge;
+
+void connectWifi() {
+  Serial.printf("Connecting to Wi-Fi SSID \"%s\" ...\n", WIFI_SSID);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+  const unsigned long startAttempt = millis();
+  while (WiFi.status() != WL_CONNECTED && (millis() - startAttempt) < WIFI_CONNECT_TIMEOUT_MS) {
+    delay(250);
+    Serial.print('.');
+  }
+  Serial.println();
+
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.printf("Wi-Fi connected, IP address: %s\n", WiFi.localIP().toString().c_str());
+  } else {
+    Serial.println("Failed to connect to Wi-Fi. Matter functionality will remain offline until the connection succeeds.");
+  }
+
+  lastWifiAttempt = millis();
+}
+
+void maintainWifiConnection() {
+  if (WiFi.status() == WL_CONNECTED) {
+    return;
+  }
+
+  const unsigned long now = millis();
+  if (now - lastWifiAttempt < WIFI_RECONNECT_INTERVAL_MS) {
+    return;
+  }
+
+  Serial.println("Wi-Fi disconnected, attempting to reconnect ...");
+  WiFi.disconnect();
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  lastWifiAttempt = now;
+}
 
 void printHeatPumpTimers(const heatpumpTimers &timers) {
   Serial.printf("  Timer mode: %s\n", timers.mode ? timers.mode : "UNKNOWN");
@@ -102,6 +190,9 @@ void setup() {
   Serial.println();
   Serial.println("ESP32 Mitsubishi Heat Pump controller demo");
 
+  connectWifi();
+  matterBridge.begin();
+
   heatPump.setSettingsChangedCallback(onHeatPumpSettingsChanged);
   heatPump.setStatusChangedCallback(onHeatPumpStatusChanged);
   heatPump.setRoomTempChangedCallback(onHeatPumpRoomTempChanged);
@@ -110,6 +201,9 @@ void setup() {
 }
 
 void loop() {
+  maintainWifiConnection();
+  matterBridge.loop();
+
   if (heatPumpConnected) {
     heatPump.sync();
   }


### PR DESCRIPTION
## Summary
- add Wi-Fi station configuration helpers and a stubbed Matter bridge heartbeat to `src/main.cpp`
- document the new Wi-Fi- and Matter-related build flags in the README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de7b901c48324a05960b9038f9064)